### PR TITLE
Add Fraxtal support

### DIFF
--- a/ethers-contract/src/multicall/constants.rs
+++ b/ethers-contract/src/multicall/constants.rs
@@ -33,6 +33,7 @@ pub const MULTICALL_SUPPORTED_CHAIN_IDS: &[u64] = {
         AvalancheFuji as u64,            // Avalanche Fuji
         FantomTestnet as u64,            // Fantom Testnet
         Fantom as u64,                   // Fantom Opera
+        Fraxtal as u64,                  // Fraxtal
         BinanceSmartChain as u64,        // BNB Smart Chain
         BinanceSmartChainTestnet as u64, // BNB Smart Chain Testnet
         Moonbeam as u64,                 // Moonbeam

--- a/ethers-contract/src/multicall/constants.rs
+++ b/ethers-contract/src/multicall/constants.rs
@@ -33,7 +33,6 @@ pub const MULTICALL_SUPPORTED_CHAIN_IDS: &[u64] = {
         AvalancheFuji as u64,            // Avalanche Fuji
         FantomTestnet as u64,            // Fantom Testnet
         Fantom as u64,                   // Fantom Opera
-        Fraxtal as u64,                  // Fraxtal
         BinanceSmartChain as u64,        // BNB Smart Chain
         BinanceSmartChainTestnet as u64, // BNB Smart Chain Testnet
         Moonbeam as u64,                 // Moonbeam
@@ -50,6 +49,7 @@ pub const MULTICALL_SUPPORTED_CHAIN_IDS: &[u64] = {
         16,                              // Coston Testnet
         114,                             // Coston2 Testnet
         288,                             // Boba
+        252,                             // Fraxtal Mainnet
         Aurora as u64,                   // Aurora
         592,                             // Astar
         66,                              // OKC

--- a/ethers-core/src/types/chain.rs
+++ b/ethers-core/src/types/chain.rs
@@ -288,6 +288,7 @@ impl Chain {
             BinanceSmartChain | BinanceSmartChainTestnet => 3_000,
             Avalanche | AvalancheFuji => 2_000,
             Fantom | FantomTestnet => 1_200,
+            Fraxtal => 2_000,
             Cronos | CronosTestnet | Canto | CantoTestnet => 5_700,
             Evmos | EvmosTestnet => 1_900,
             Aurora | AuroraTestnet => 1_100,

--- a/ethers-core/src/types/chain.rs
+++ b/ethers-core/src/types/chain.rs
@@ -352,6 +352,7 @@ impl Chain {
             Optimism |
             OptimismGoerli |
             Polygon |
+            Fraxtal |
             PolygonMumbai |
             Avalanche |
             AvalancheFuji |

--- a/ethers-core/src/types/chain.rs
+++ b/ethers-core/src/types/chain.rs
@@ -107,6 +107,7 @@ pub enum Chain {
     PolygonZkEvmTestnet = 1442,
 
     Fantom = 250,
+    Fraxtal = 252,
     FantomTestnet = 4002,
 
     Moonbeam = 1284,
@@ -443,6 +444,8 @@ impl Chain {
             Fantom => ("https://api.ftmscan.com/api", "https://ftmscan.com"),
             FantomTestnet => ("https://api-testnet.ftmscan.com/api", "https://testnet.ftmscan.com"),
 
+            Fraxtal => ("https://api.fraxscan.com/api", "https://fraxscan.com"),
+
             BinanceSmartChain => ("https://api.bscscan.com/api", "https://bscscan.com"),
             BinanceSmartChainTestnet => {
                 ("https://api-testnet.bscscan.com/api", "https://testnet.bscscan.com")
@@ -596,6 +599,8 @@ impl Chain {
             Polygon | PolygonMumbai | PolygonZkEvm | PolygonZkEvmTestnet => "POLYGONSCAN_API_KEY",
 
             Fantom | FantomTestnet => "FTMSCAN_API_KEY",
+
+            Fraxtal => "FRAXTALSCAN_API_KEY",
 
             Moonbeam | Moonbase | MoonbeamDev | Moonriver => "MOONSCAN_API_KEY",
 


### PR DESCRIPTION
Require new env variable: `FRAXTALSCAN_API_KEY`

from https://fraxscan.com/
